### PR TITLE
SCA-55267: skipping analysis for massive number of component vim-vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.1] - 2024-10-09
+### Changed
+-Check for vim-vim component, API takes a long time due to the massive number of versions
+
 ## [6.3.0] - 2023-10-16
 ### Changed
 - Move to common submodule with support for tomcat upgrade

--- a/_version.py
+++ b/_version.py
@@ -7,4 +7,4 @@ Author : sgeary
 Created On : Tue Sep 01 2020
 File : _version.py
 '''
-__version__ = "6.3.0"
+__version__ = "6.3.1"

--- a/report_data.py
+++ b/report_data.py
@@ -200,6 +200,10 @@ def gather_data_for_report(baseURL, projectID, authToken, reportData):
                         # The API call for the versions of linux takes a long time due to teh massive number of versions so bypass
                         logger.debug("Linux kernel so skipping version analysis")
                         complianceIssues["Version not analyzed"] = "This versions for this component have not beeen analyzed. Manual inspection is suggested"
+                    elif componentID == "6682478":  # Is it the vim-vim?
+                        # The API call for the versions of vim-vim takes a long time due to the massive number of versions so bypass
+                        logger.debug("vim-vim so skipping version analysis")
+                        complianceIssues["Version not analyzed"] = "This versions for this component have not beeen analyzed. Manual inspection is suggested"
                     else:
                     #    Determine if there are any issues with the version
                         componentVersionDetails = getVersionDetails(componentVersionName, componentID, baseURL, authToken)


### PR DESCRIPTION
Jira: SCA-55267
Component: vim-vim(https://github.com/vim/vim) currently has around 16,947 versions.
The "Get Component API" is unresponsive when handling components with a large number of versions. To address this, the process has been bypassed to ensure the report generation does not hang.
 

